### PR TITLE
Encode lists as indefinite length when non-empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,8 @@ dependencies = [
 name = "plutus-parser-tests"
 version = "0.1.0"
 dependencies = [
+ "hex",
+ "minicbor 0.25.1",
  "plutus-parser",
 ]
 

--- a/packages/plutus-parser-tests/Cargo.toml
+++ b/packages/plutus-parser-tests/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 plutus-parser = { path = "../plutus-parser", features = ["derive"] }
+hex = "0.4.3"
+minicbor = "0.25.1"

--- a/packages/plutus-parser-tests/tests/tests.rs
+++ b/packages/plutus-parser-tests/tests/tests.rs
@@ -135,7 +135,7 @@ fn should_support_arrays() {
 
     let plutus = create_constr(
         0,
-        vec![PlutusData::Array(MaybeIndefArray::Def(vec![
+        vec![PlutusData::Array(MaybeIndefArray::Indef(vec![
             PlutusData::BoundedBytes(BoundedBytes::from("cafe".bytes().collect::<Vec<_>>())),
         ]))],
     );
@@ -213,4 +213,32 @@ fn should_support_custom_variants_for_enums() {
     let plutus = create_constr(1, vec![]);
 
     assert_encoded(data, plutus);
+}
+
+#[test]
+fn should_match_plutus_conventions() {
+    #[derive(AsPlutus, Clone)]
+    pub enum Optional {
+        Some(u32),
+        None
+    }
+
+    #[derive(AsPlutus, Clone)]
+    pub struct Fields {
+        pub a: u32,
+        pub b: u32,
+        pub c: Optional,
+        pub d: Optional,
+    }
+    let data = Fields {
+        a: 1,
+        b: 2,
+        c: Optional::Some(3),
+        d: Optional::None,
+    };
+    let expected_bytes = hex::decode("d8799f0102d8799f03ffd87a80ff").unwrap();
+    let mut enc_bytes = vec![];
+    minicbor::encode(data.to_plutus(), &mut enc_bytes).expect("infallible");
+
+    assert_eq!(enc_bytes, expected_bytes);
 }

--- a/packages/plutus-parser/src/lib.rs
+++ b/packages/plutus-parser/src/lib.rs
@@ -121,12 +121,12 @@ pub fn create_constr(variant: u64, fields: Vec<PlutusData>) -> PlutusData {
     PlutusData::Constr(Constr {
         tag,
         any_constructor,
-        fields: MaybeIndefArray::Def(fields),
+        fields: if fields.len() > 0 { MaybeIndefArray::Indef(fields) } else { MaybeIndefArray::Def(Vec::new()) },
     })
 }
 
 pub fn create_array(fields: Vec<PlutusData>) -> PlutusData {
-    PlutusData::Array(MaybeIndefArray::Def(fields))
+    PlutusData::Array(if fields.len() > 0 { MaybeIndefArray::Indef(fields) } else { MaybeIndefArray::Def(Vec::new()) })
 }
 
 pub fn create_map(kvps: Vec<(PlutusData, PlutusData)>) -> PlutusData {


### PR DESCRIPTION
This matches the plutus convention, which allows things to round-trip through cbor serialization in plutus code, for signatures.