### PR TITLE
Add to_plutus_bytes and from_plutus_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,10 @@ dependencies = [
 name = "plutus-parser"
 version = "0.2.0"
 dependencies = [
+ "hex",
  "indexmap",
+ "minicbor 0.25.1",
+ "minicbor 0.26.5",
  "pallas-primitives 0.32.1",
  "pallas-primitives 0.33.0",
  "pallas-primitives 1.0.0-alpha.3",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A simple crate to derive `from_plutus` and `to_plutus` on Rust types.
 
 This crate matches Aiken semantics as closely as possible.
 
+## API
+
+Derive `AsPlutus` on your types, no mandatory annotations.
 ```rs
 use plutus_parser::{AsPlutus, BigInt, BoundedBytes, Constr, Int, MaybeIndefArray, PlutusData};
 
@@ -19,8 +22,27 @@ pub enum BlockReference {
     Origin,
     Point(Vec<u8>),
 }
+```
 
-fn main() {
+This library derives a set of conventions:
+ - Structs convert to a `PlutusData::Constr` using variant `0`. You can add `#[variant = 2]` to use a different variant.
+ - Enums convert to a `PlutusData::Constr`. The first variant uses variant 0, the second uses variant 1, nad so on. You can add `#[variant = 2]` to an individual variant to override this.
+ - Tuples convert to an `PlutusData::Array`.
+ - Arrays and vectors both convert to a `PlutusData::Array`, except for `Vec<u8>` which converts to a `PlutusData::BoundedBytes`.
+ - Numeric fields convert to a `PlutusData::Integer`.
+ - `bool` fields convert to a `PlutusData::Constr` enum, following Aiken semantics: `false` uses variant `0`, `true` uses variant `1`.
+ - `Option<T>` fields convert to a `PlutusData::Constr` enum, following Aiken semantics: `Some(x)` uses variant `0`, `None` uses variant `1`.
+ - `String` fields convert to a `PlutusData::BoundedBytes` containing the string contents.
+ - `Vec<u8>` fields convert to a `PlutusData::BoundedBytes`.
+
+## Usage
+
+Use `T::from_plutus` to convert a `PlutusData` instance into your type, and use `T::to_plutus` to convert your type into a `PlutusData` instance.
+
+```rs
+use plutus_parser::{BigInt, BoundedBytes, Constr, Int, MaybeIndefArray, PlutusData};
+
+fn to_from_plutus() {
     let data = MyType {
         token_name: "SUNDAE".to_string(),
         token_value: 13379001,
@@ -30,16 +52,16 @@ fn main() {
     let plutus = PlutusData::Constr(Constr {
         tag: 121,
         any_constructor: None,
-        fields: MaybeIndefArray::Def(vec![
+        fields: MaybeIndefArray::Indef(vec![
             PlutusData::BoundedBytes(BoundedBytes::from("SUNDAE".as_bytes().to_vec())),
             PlutusData::BigInt(BigInt::Int(Int::from(13379001))),
             PlutusData::Constr(Constr {
                 tag: 121,
                 any_constructor: None,
-                fields: MaybeIndefArray::Def(vec![PlutusData::Constr(Constr {
+                fields: MaybeIndefArray::Indef(vec![PlutusData::Constr(Constr {
                     tag: 122,
                     any_constructor: None,
-                    fields: MaybeIndefArray::Def(vec![PlutusData::BoundedBytes(
+                    fields: MaybeIndefArray::Indef(vec![PlutusData::BoundedBytes(
                         BoundedBytes::from(vec![0x12, 0x24]),
                     )]),
                 })]),
@@ -49,5 +71,21 @@ fn main() {
 
     assert_eq!(MyType::from_plutus(plutus.clone()).unwrap(), data);
     assert_eq!(data.to_plutus(), plutus);
+```
+
+To avoid a direct `pallas` dependency, you can also use `T::from_plutus_bytes` and `T::to_plutus_bytes` to work directly with bytes.
+```rs
+fn to_from_plutus_bytes() {
+    let data = MyType {
+        token_name: "SUNDAE".to_string(),
+        token_value: 13379001,
+        block_ref: Some(BlockReference::Point(vec![0x12, 0x24])),
+    };
+
+    let plutus_bytes: Vec<u8> =
+        hex::decode("d8799f4653554e4441451a00cc25b9d8799fd87a9f421224ffffff").unwrap();
+
+    assert_eq!(MyType::from_plutus_bytes(&plutus_bytes).unwrap(), data);
+    assert_eq!(data.to_plutus_bytes(), plutus_bytes);
 }
 ```

--- a/packages/plutus-parser-tests/tests/tests.rs
+++ b/packages/plutus-parser-tests/tests/tests.rs
@@ -274,3 +274,23 @@ fn should_encode_and_decode_bytes() {
     let data2 = Basic::from_plutus_bytes(&bytes).unwrap();
     assert_eq!(data, data2);
 }
+
+#[test]
+fn should_support_plutus_data_fields() {
+    #[derive(AsPlutus, Clone, Debug, PartialEq, Eq)]
+    struct Basic {
+        data: PlutusData,
+    }
+
+    let data = Basic {
+        data: PlutusData::BoundedBytes(vec![0xca, 0xfe, 0xba, 0xbe].into()),
+    };
+    let plutus = create_constr(
+        0,
+        vec![PlutusData::BoundedBytes(
+            vec![0xca, 0xfe, 0xba, 0xbe].into(),
+        )],
+    );
+
+    assert_encoded(data, plutus);
+}

--- a/packages/plutus-parser-tests/tests/tests.rs
+++ b/packages/plutus-parser-tests/tests/tests.rs
@@ -256,3 +256,21 @@ fn should_support_multiple_enum_fields() {
 
     assert_encoded(data, plutus);
 }
+
+#[test]
+fn should_encode_and_decode_bytes() {
+    #[derive(AsPlutus, Clone, Debug, PartialEq, Eq)]
+    struct Basic {
+        name: String,
+    }
+
+    let data = Basic {
+        name: "Hello world!".to_string(),
+    };
+
+    let bytes = data.clone().to_plutus_bytes();
+    assert_eq!(hex::encode(&bytes), "d8799f4c48656c6c6f20776f726c6421ff");
+
+    let data2 = Basic::from_plutus_bytes(&bytes).unwrap();
+    assert_eq!(data, data2);
+}

--- a/packages/plutus-parser/Cargo.toml
+++ b/packages/plutus-parser/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/SundaeSwap-finance/plutus-parser/"
 
 [dependencies]
 indexmap = "2"
+minicbor-v0_25 = { package = "minicbor", version = "0.25", optional = true }
+minicbor-v0_26 = { package = "minicbor", version = "0.26", optional = true }
 pallas-v0_32 = { package = "pallas-primitives", version = "0.32", optional = true }
 pallas-v0_33 = { package = "pallas-primitives", version = "0.33", optional = true }
 pallas-v1 = { package = "pallas-primitives", version = "1.0.0-alpha.3", optional = true }
@@ -15,14 +17,15 @@ plutus-parser-derive = { path = "../plutus-parser-derive", version = "0.2.0", op
 thiserror = "2"
 
 [dev-dependencies]
+hex = "0.4"
 plutus-parser-derive = { path = "../plutus-parser-derive" }
 
 [features]
 default = ["pallas-v0_32"]
 derive = ["dep:plutus-parser-derive"]
-pallas-v0_32 = ["dep:pallas-v0_32"]
-pallas-v0_33 = ["dep:pallas-v0_33"]
-pallas-v1 = ["dep:pallas-v1"]
+pallas-v0_32 = ["dep:pallas-v0_32", "dep:minicbor-v0_25"]
+pallas-v0_33 = ["dep:pallas-v0_33", "dep:minicbor-v0_25"]
+pallas-v1 = ["dep:pallas-v1", "dep:minicbor-v0_26"]
 
 [[example]]
 name = "example"

--- a/packages/plutus-parser/Cargo.toml
+++ b/packages/plutus-parser/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4"
 plutus-parser-derive = { path = "../plutus-parser-derive" }
 
 [features]
-default = ["pallas-v0_32"]
+default = ["pallas-v0_33"]
 derive = ["dep:plutus-parser-derive"]
 pallas-v0_32 = ["dep:pallas-v0_32", "dep:minicbor-v0_25"]
 pallas-v0_33 = ["dep:pallas-v0_33", "dep:minicbor-v0_25"]

--- a/packages/plutus-parser/examples/example.rs
+++ b/packages/plutus-parser/examples/example.rs
@@ -14,6 +14,11 @@ pub enum BlockReference {
 }
 
 fn main() {
+    to_from_plutus();
+    to_from_plutus_bytes();
+}
+
+fn to_from_plutus() {
     let data = MyType {
         token_name: "SUNDAE".to_string(),
         token_value: 13379001,
@@ -23,16 +28,16 @@ fn main() {
     let plutus = PlutusData::Constr(Constr {
         tag: 121,
         any_constructor: None,
-        fields: MaybeIndefArray::Def(vec![
+        fields: MaybeIndefArray::Indef(vec![
             PlutusData::BoundedBytes(BoundedBytes::from("SUNDAE".as_bytes().to_vec())),
             PlutusData::BigInt(BigInt::Int(Int::from(13379001))),
             PlutusData::Constr(Constr {
                 tag: 121,
                 any_constructor: None,
-                fields: MaybeIndefArray::Def(vec![PlutusData::Constr(Constr {
+                fields: MaybeIndefArray::Indef(vec![PlutusData::Constr(Constr {
                     tag: 122,
                     any_constructor: None,
-                    fields: MaybeIndefArray::Def(vec![PlutusData::BoundedBytes(
+                    fields: MaybeIndefArray::Indef(vec![PlutusData::BoundedBytes(
                         BoundedBytes::from(vec![0x12, 0x24]),
                     )]),
                 })]),
@@ -42,4 +47,18 @@ fn main() {
 
     assert_eq!(MyType::from_plutus(plutus.clone()).unwrap(), data);
     assert_eq!(data.to_plutus(), plutus);
+}
+
+fn to_from_plutus_bytes() {
+    let data = MyType {
+        token_name: "SUNDAE".to_string(),
+        token_value: 13379001,
+        block_ref: Some(BlockReference::Point(vec![0x12, 0x24])),
+    };
+
+    let plutus_bytes: Vec<u8> =
+        hex::decode("d8799f4653554e4441451a00cc25b9d8799fd87a9f421224ffffff").unwrap();
+
+    assert_eq!(MyType::from_plutus_bytes(&plutus_bytes).unwrap(), data);
+    assert_eq!(data.to_plutus_bytes(), plutus_bytes);
 }

--- a/packages/plutus-parser/src/lib.rs
+++ b/packages/plutus-parser/src/lib.rs
@@ -4,15 +4,21 @@ mod primitives;
 pub use plutus_parser_derive::*;
 
 #[cfg(feature = "pallas-v0_32")]
+pub use minicbor_v0_25 as minicbor;
+#[cfg(feature = "pallas-v0_32")]
 pub use pallas_v0_32::{
     BigInt, BoundedBytes, Constr, Int, KeyValuePairs, MaybeIndefArray, PlutusData,
 };
 
 #[cfg(feature = "pallas-v0_33")]
+pub use minicbor_v0_25 as minicbor;
+#[cfg(feature = "pallas-v0_33")]
 pub use pallas_v0_33::{
     BigInt, BoundedBytes, Constr, Int, KeyValuePairs, MaybeIndefArray, PlutusData,
 };
 
+#[cfg(feature = "pallas-v1")]
+pub use minicbor_v0_26 as minicbor;
 #[cfg(feature = "pallas-v1")]
 pub use pallas_v1::{
     BigInt, BoundedBytes, Constr, Int, KeyValuePairs, MaybeIndefArray, PlutusData,
@@ -34,6 +40,8 @@ pub enum DecodeError {
         expected: usize,
         actual: usize,
     },
+    #[error("invalid cbor: {0}")]
+    InvalidCbor(minicbor::decode::Error),
     #[error("{0}")]
     Custom(String),
 }
@@ -41,6 +49,16 @@ pub enum DecodeError {
 pub trait AsPlutus: Sized {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError>;
     fn to_plutus(self) -> PlutusData;
+
+    fn from_plutus_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let data = minicbor::decode::<PlutusData>(bytes).map_err(DecodeError::InvalidCbor)?;
+        Self::from_plutus(data)
+    }
+
+    fn to_plutus_bytes(self) -> Vec<u8> {
+        let data = self.to_plutus();
+        minicbor::to_vec(data).expect("infallible")
+    }
 
     fn vec_from_plutus(data: PlutusData) -> Result<Vec<Self>, DecodeError> {
         let items = parse_array(data)?;

--- a/packages/plutus-parser/src/primitives.rs
+++ b/packages/plutus-parser/src/primitives.rs
@@ -10,6 +10,16 @@ use crate::{
     create_map, parse_constr, parse_map, parse_tuple, parse_variant, type_name,
 };
 
+impl AsPlutus for PlutusData {
+    fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
+        Ok(data)
+    }
+
+    fn to_plutus(self) -> PlutusData {
+        self
+    }
+}
+
 impl AsPlutus for BigInt {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
         let PlutusData::BigInt(int) = data else {


### PR DESCRIPTION
Pallas has several different versions active in the wild, and different versions of it use different versions of minicbor. Avoid dependency hell by adding `from_plutus_bytes` and `to_plutus_bytes` helpers. These accept `&[u8]` and return `Vec<u8>`, respectively, so you can use this module without your own explicit pallas dependency.

Also, allow structs to contain `PlutusData` fields directly.

Also, bump the default pallas version to `0.33`.