### PR TITLE
Improve error messages

### DIFF
--- a/packages/plutus-parser-derive/src/lib.rs
+++ b/packages/plutus-parser-derive/src/lib.rs
@@ -27,7 +27,7 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                         .collect();
                     let assignments = names.iter().map(|n| {
                         quote! {
-                            #n: plutus_parser::AsPlutus::from_plutus(#n)?,
+                            #n: plutus_parser::AsPlutus::from_plutus(#n).map_err(|e| e.with_field_name(stringify!(#n)))?,
                         }
                     });
                     let casts: Vec<_> = names
@@ -47,7 +47,7 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                                 #(#assignments)*
                             });
                         }
-                        Err(plutus_parser::DecodeError::UnexpectedVariant { variant })
+                        Err(plutus_parser::DecodeError::unexpected_variant(variant))
                     };
                     to_plutus = quote! {
                         plutus_parser::create_constr(#n, vec![
@@ -62,7 +62,7 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                             let [] = plutus_parser::parse_variant(variant, fields)?;
                             return Ok(Self);
                         }
-                        Err(plutus_parser::DecodeError::UnexpectedVariant { variant })
+                        Err(plutus_parser::DecodeError::unexpected_variant(variant))
                     };
                     to_plutus = quote! {
                         plutus_parser::create_constr(#n, vec![])
@@ -81,9 +81,10 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                         .collect();
                     let assignments: Vec<_> = names
                         .iter()
-                        .map(|n| {
+                        .enumerate()
+                        .map(|(i, n)| {
                             quote! {
-                                plutus_parser::AsPlutus::from_plutus(#n)?,
+                                plutus_parser::AsPlutus::from_plutus(#n).map_err(|e| e.with_field_name(#i))?,
                             }
                         })
                         .collect();
@@ -101,7 +102,7 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                             let [#(#names),*] = plutus_parser::parse_variant(variant, fields)?;
                             return Ok(Self(#(#assignments)*));
                         }
-                        Err(plutus_parser::DecodeError::UnexpectedVariant { variant })
+                        Err(plutus_parser::DecodeError::unexpected_variant(variant))
                     };
                     to_plutus = quote! {
                         let Self(#(#names),*) = self;
@@ -140,8 +141,9 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                             .map(|n| n.ident.as_ref().unwrap())
                             .collect();
                         let assignments = names.iter().map(|n| {
+                            let field_name = format!("::{name}.{n}");
                             quote! {
-                                #n: plutus_parser::AsPlutus::from_plutus(#n)?,
+                                #n: plutus_parser::AsPlutus::from_plutus(#n).map_err(|e| e.with_field_name(#field_name))?,
                             }
                         });
                         let casts: Vec<_> = names
@@ -188,9 +190,11 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                             .collect();
                         let assignments: Vec<_> = names
                             .iter()
-                            .map(|n| {
+                            .enumerate()
+                            .map(|(i, n)| {
+                                let field_name = format!("::{name}.{i}");
                                 quote! {
-                                    plutus_parser::AsPlutus::from_plutus(#n)?,
+                                    plutus_parser::AsPlutus::from_plutus(#n).map_err(|e| e.with_field_name(#field_name))?,
                                 }
                             })
                             .collect();
@@ -225,7 +229,7 @@ pub fn derive_as_plutus(input: TokenStream) -> TokenStream {
                 });
             }
             from_plutus.extend(quote! {
-                Err(plutus_parser::DecodeError::UnexpectedVariant { variant })
+                Err(plutus_parser::DecodeError::unexpected_variant(variant))
             });
 
             quote! {

--- a/packages/plutus-parser-tests/tests/tests.rs
+++ b/packages/plutus-parser-tests/tests/tests.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use plutus_parser::{
-    AsPlutus, BigInt, BoundedBytes, MaybeIndefArray, PlutusData, create_array, create_constr,
-    create_map,
+    AsPlutus, BigInt, BoundedBytes, DecodeError, MaybeIndefArray, PlutusData, create_array,
+    create_constr, create_map,
 };
 use plutus_parser_tests::{Interval, IntervalBound, IntervalBoundType};
 
@@ -293,4 +293,270 @@ fn should_support_plutus_data_fields() {
     );
 
     assert_encoded(data, plutus);
+}
+
+#[test]
+fn should_include_field_names_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Basic {
+        not_an_int: bool,
+    }
+
+    let plutus = create_constr(0, vec![PlutusData::BigInt(BigInt::Int(1.into()))]);
+
+    let error = DecodeError::unexpected_type("Constr", "BigInt").with_field_name("not_an_int");
+
+    assert_eq!(Basic::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_nested_field_names_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Outer {
+        foo: Option<Inner>,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Inner {
+        bar: bool,
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_constr(
+            0,
+            vec![create_constr(0, vec![create_constr(2, vec![])])],
+        )],
+    );
+
+    let error = DecodeError::unexpected_variant(2).with_field_name("foo.bar");
+
+    assert_eq!(Outer::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_nested_field_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Outer {
+        foo: Option<Inner>,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Inner(bool);
+
+    let plutus = create_constr(
+        0,
+        vec![create_constr(
+            0,
+            vec![create_constr(0, vec![create_constr(2, vec![])])],
+        )],
+    );
+
+    let error = DecodeError::unexpected_variant(2).with_field_name("foo.0");
+
+    assert_eq!(Outer::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_array_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Collection {
+        items: Vec<Item>,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Item {
+        foo: Option<String>,
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_array(vec![
+            create_constr(
+                0,
+                vec![create_constr(
+                    0,
+                    vec![PlutusData::BoundedBytes(vec![0x01].into())],
+                )],
+            ),
+            create_constr(
+                0,
+                vec![create_constr(
+                    0,
+                    vec![PlutusData::BoundedBytes(vec![0x02].into())],
+                )],
+            ),
+            create_constr(
+                0,
+                vec![create_constr(
+                    1,
+                    vec![PlutusData::BoundedBytes(vec![0x03].into())],
+                )],
+            ),
+        ])],
+    );
+
+    let error = DecodeError::wrong_variant_field_count(1, 0, 1).with_field_name("items[2].foo");
+
+    assert_eq!(Collection::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_tuple_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Collection {
+        items: (Item, Item, Item),
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Item {
+        foo: Option<String>,
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_array(vec![
+            create_constr(
+                0,
+                vec![create_constr(
+                    0,
+                    vec![PlutusData::BoundedBytes(vec![0x01].into())],
+                )],
+            ),
+            create_constr(
+                0,
+                vec![create_constr(
+                    0,
+                    vec![PlutusData::BoundedBytes(vec![0x02].into())],
+                )],
+            ),
+            create_constr(
+                0,
+                vec![create_constr(
+                    1,
+                    vec![PlutusData::BoundedBytes(vec![0x03].into())],
+                )],
+            ),
+        ])],
+    );
+
+    let error = DecodeError::wrong_variant_field_count(1, 0, 1).with_field_name("items.2.foo");
+
+    assert_eq!(Collection::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_map_key_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Lookup {
+        by_name: HashMap<String, u64>,
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_map(vec![
+            (
+                PlutusData::BoundedBytes(vec![0x68, 0x65, 0x6c, 0x6c, 0x6f].into()),
+                PlutusData::BigInt(BigInt::Int(69.into())),
+            ),
+            (
+                PlutusData::BoundedBytes(vec![0x00, 0x9f, 0x92, 0x96].into()),
+                PlutusData::BigInt(BigInt::Int(67.into())),
+            ),
+        ])],
+    );
+
+    let error = DecodeError::custom(
+        "error decoding string: invalid utf-8 sequence of 1 bytes from index 1",
+    )
+    .with_field_name("by_name[(key #1)]");
+
+    assert_eq!(Lookup::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_map_value_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Values {
+        by_index: BTreeMap<u64, Value>,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Value {
+        id: u8,
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_map(vec![
+            (
+                PlutusData::BigInt(BigInt::Int(3.into())),
+                create_constr(0, vec![PlutusData::BigInt(BigInt::Int(4.into()))]),
+            ),
+            (
+                PlutusData::BigInt(BigInt::Int(3.into())),
+                create_constr(0, vec![create_constr(0, vec![])]),
+            ),
+        ])],
+    );
+
+    let error =
+        DecodeError::unexpected_type("BigInt", "Constr").with_field_name("by_index[(value #1)].id");
+
+    assert_eq!(Values::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_enum_variant_field_names_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    enum Inner {
+        First { field: u8 },
+        Second(u16),
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_constr(
+            0,
+            vec![PlutusData::BigInt(BigInt::Int(257.into()))],
+        )],
+    );
+
+    let error = DecodeError::out_of_range(257).with_field_name("inner::First.field");
+
+    assert_eq!(Outer::from_plutus(plutus), Err(error));
+}
+
+#[test]
+fn should_include_enum_variant_field_indices_in_errors() {
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(AsPlutus, Debug, PartialEq, Eq)]
+    enum Inner {
+        First { field: u8 },
+        Second(u16),
+    }
+
+    let plutus = create_constr(
+        0,
+        vec![create_constr(
+            1,
+            vec![PlutusData::BigInt(BigInt::BigUInt(
+                vec![0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].into(),
+            ))],
+        )],
+    );
+
+    let error =
+        DecodeError::out_of_range("0x010000000000000000").with_field_name("inner::Second.0");
+
+    assert_eq!(Outer::from_plutus(plutus), Err(error));
 }

--- a/packages/plutus-parser/Cargo.toml
+++ b/packages/plutus-parser/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/SundaeSwap-finance/plutus-parser/"
 
 [dependencies]
+hex = "0.4"
 indexmap = "2"
 minicbor-v0_25 = { package = "minicbor", version = "0.25", optional = true }
 minicbor-v0_26 = { package = "minicbor", version = "0.26", optional = true }

--- a/packages/plutus-parser/src/lib.rs
+++ b/packages/plutus-parser/src/lib.rs
@@ -33,8 +33,72 @@ pub use pallas_v1::{
 
 use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum DecodeError {
+#[derive(Error, Debug, PartialEq, Eq)]
+#[error("decode error at {path}: {kind}")]
+pub struct DecodeError {
+    kind: DecodeErrorKind,
+    path: String,
+}
+
+impl DecodeError {
+    pub fn new(kind: DecodeErrorKind) -> Self {
+        Self {
+            kind,
+            path: String::new(),
+        }
+    }
+
+    pub fn unexpected_variant(variant: u64) -> Self {
+        Self::new(DecodeErrorKind::UnexpectedVariant { variant })
+    }
+
+    pub fn unexpected_type<E: Into<String>, A: Into<String>>(expected: E, actual: A) -> Self {
+        Self::new(DecodeErrorKind::UnexpectedType {
+            expected: expected.into(),
+            actual: actual.into(),
+        })
+    }
+
+    pub fn wrong_tuple_field_count(expected: usize, actual: usize) -> Self {
+        Self::new(DecodeErrorKind::WrongTupleFieldCount { expected, actual })
+    }
+
+    pub fn wrong_variant_field_count(variant: u64, expected: usize, actual: usize) -> Self {
+        Self::new(DecodeErrorKind::WrongVariantFieldCount {
+            variant,
+            expected,
+            actual,
+        })
+    }
+
+    pub fn out_of_range(value: impl std::fmt::Display) -> Self {
+        Self::new(DecodeErrorKind::OutOfRange {
+            value: value.to_string(),
+        })
+    }
+
+    pub fn invalid_cbor(error: minicbor::decode::Error) -> Self {
+        Self::new(DecodeErrorKind::InvalidCbor(MinicborDecodeError(error)))
+    }
+
+    pub fn custom(message: impl Into<String>) -> Self {
+        Self::new(DecodeErrorKind::Custom(message.into()))
+    }
+
+    pub fn with_field_name(mut self, name: impl std::fmt::Display) -> Self {
+        if self.path.is_empty() {
+            self.path = name.to_string();
+        } else if self.path.starts_with("[") || self.path.starts_with(":") {
+            self.path = format!("{name}{}", self.path);
+        } else {
+            self.path = format!("{name}.{}", self.path);
+        }
+        self
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum DecodeErrorKind {
     #[error("unexpected variant {variant}")]
     UnexpectedVariant { variant: u64 },
     #[error("unexpected type (expected {expected}, found {actual})")]
@@ -47,18 +111,30 @@ pub enum DecodeError {
         expected: usize,
         actual: usize,
     },
+    #[error("value {value} out of range")]
+    OutOfRange { value: String },
     #[error("invalid cbor: {0}")]
-    InvalidCbor(minicbor::decode::Error),
+    InvalidCbor(MinicborDecodeError),
     #[error("{0}")]
     Custom(String),
 }
+
+#[derive(Error, Debug)]
+#[error("{0}")]
+pub struct MinicborDecodeError(minicbor::decode::Error);
+impl PartialEq for MinicborDecodeError {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_string() == other.0.to_string()
+    }
+}
+impl Eq for MinicborDecodeError {}
 
 pub trait AsPlutus: Sized {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError>;
     fn to_plutus(self) -> PlutusData;
 
     fn from_plutus_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let data = minicbor::decode::<PlutusData>(bytes).map_err(DecodeError::InvalidCbor)?;
+        let data = minicbor::decode::<PlutusData>(bytes).map_err(DecodeError::invalid_cbor)?;
         Self::from_plutus(data)
     }
 
@@ -69,7 +145,13 @@ pub trait AsPlutus: Sized {
 
     fn vec_from_plutus(data: PlutusData) -> Result<Vec<Self>, DecodeError> {
         let items = parse_array(data)?;
-        items.into_iter().map(Self::from_plutus).collect()
+        items
+            .into_iter()
+            .enumerate()
+            .map(|(index, item)| {
+                Self::from_plutus(item).map_err(|e| e.with_field_name(format!("[{index}]")))
+            })
+            .collect()
     }
 
     fn vec_to_plutus(value: Vec<Self>) -> PlutusData {
@@ -81,10 +163,7 @@ pub fn parse_array(data: PlutusData) -> Result<Vec<PlutusData>, DecodeError> {
     let array = match data {
         PlutusData::Array(array) => array,
         other => {
-            return Err(DecodeError::UnexpectedType {
-                expected: "Array".to_string(),
-                actual: type_name(&other),
-            });
+            return Err(DecodeError::unexpected_type("Array", type_name(&other)));
         }
     };
     Ok(array.to_vec())
@@ -94,24 +173,18 @@ pub fn parse_tuple<const N: usize>(data: PlutusData) -> Result<[PlutusData; N], 
     let array = parse_array(data)?;
     array
         .try_into()
-        .map_err(|f: Vec<PlutusData>| DecodeError::WrongTupleFieldCount {
-            expected: N,
-            actual: f.len(),
-        })
+        .map_err(|f: Vec<PlutusData>| DecodeError::wrong_tuple_field_count(N, f.len()))
 }
 
 pub fn parse_constr(data: PlutusData) -> Result<(u64, Vec<PlutusData>), DecodeError> {
     let constr = match data {
         PlutusData::Constr(constr) => constr,
         other => {
-            return Err(DecodeError::UnexpectedType {
-                expected: "Constr".to_string(),
-                actual: type_name(&other),
-            });
+            return Err(DecodeError::unexpected_type("Constr", type_name(&other)));
         }
     };
     let Some(variant) = constr.constructor_value() else {
-        return Err(DecodeError::Custom("value has invalid tag".to_string()));
+        return Err(DecodeError::custom("value has invalid tag"));
     };
     Ok((variant, constr.fields.to_vec()))
 }
@@ -122,21 +195,14 @@ pub fn parse_variant<const N: usize>(
 ) -> Result<[PlutusData; N], DecodeError> {
     fields
         .try_into()
-        .map_err(|f: Vec<PlutusData>| DecodeError::WrongVariantFieldCount {
-            variant,
-            expected: N,
-            actual: f.len(),
-        })
+        .map_err(|f: Vec<PlutusData>| DecodeError::wrong_variant_field_count(variant, N, f.len()))
 }
 
 pub fn parse_map(data: PlutusData) -> Result<Vec<(PlutusData, PlutusData)>, DecodeError> {
     let kvps = match data {
         PlutusData::Map(kvps) => kvps,
         other => {
-            return Err(DecodeError::UnexpectedType {
-                expected: "Map".to_string(),
-                actual: type_name(&other),
-            });
+            return Err(DecodeError::unexpected_type("Map", type_name(&other)));
         }
     };
     Ok(kvps.to_vec())
@@ -171,7 +237,7 @@ pub fn create_map(kvps: Vec<(PlutusData, PlutusData)>) -> PlutusData {
     PlutusData::Map(KeyValuePairs::Def(kvps))
 }
 
-pub(crate) fn type_name(data: &PlutusData) -> String {
+pub(crate) fn type_name(data: &PlutusData) -> &str {
     match data {
         PlutusData::Array(_) => "Array",
         PlutusData::BigInt(_) => "BigInt",
@@ -179,5 +245,4 @@ pub(crate) fn type_name(data: &PlutusData) -> String {
         PlutusData::Constr(_) => "Constr",
         PlutusData::Map(_) => "Map",
     }
-    .to_string()
 }

--- a/packages/plutus-parser/src/primitives.rs
+++ b/packages/plutus-parser/src/primitives.rs
@@ -23,10 +23,7 @@ impl AsPlutus for PlutusData {
 impl AsPlutus for BigInt {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
         let PlutusData::BigInt(int) = data else {
-            return Err(DecodeError::UnexpectedType {
-                expected: "BigInt".to_string(),
-                actual: type_name(&data),
-            });
+            return Err(DecodeError::unexpected_type("BigInt", type_name(&data)));
         };
         Ok(int)
     }
@@ -39,10 +36,10 @@ impl AsPlutus for BigInt {
 impl AsPlutus for BoundedBytes {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
         let PlutusData::BoundedBytes(bytes) = data else {
-            return Err(DecodeError::UnexpectedType {
-                expected: "BoundedBytes".to_string(),
-                actual: type_name(&data),
-            });
+            return Err(DecodeError::unexpected_type(
+                "BoundedBytes",
+                type_name(&data),
+            ));
         };
         Ok(bytes)
     }
@@ -63,7 +60,7 @@ impl AsPlutus for bool {
             let [] = parse_variant(variant, fields)?;
             return Ok(true);
         }
-        Err(DecodeError::UnexpectedVariant { variant })
+        Err(DecodeError::unexpected_variant(variant))
     }
 
     fn to_plutus(self) -> PlutusData {
@@ -77,14 +74,23 @@ impl AsPlutus for bool {
 macro_rules! impl_number {
     () => {
         fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
-            let PlutusData::BigInt(BigInt::Int(value)) = data else {
-                return Err(DecodeError::UnexpectedType {
-                    expected: "BigInt".into(),
-                    actual: type_name(&data),
-                });
+            let PlutusData::BigInt(value) = data else {
+                return Err(DecodeError::unexpected_type("BigInt", type_name(&data)));
             };
-            let value: i128 = value.into();
-            Ok(value as _)
+            match value {
+                BigInt::Int(value) => {
+                    let value: i128 = value.into();
+                    Self::try_from(value).map_err(|_| DecodeError::out_of_range(value))
+                }
+                BigInt::BigUInt(value) => Err(DecodeError::out_of_range(format!(
+                    "0x{}",
+                    hex::encode(&*value)
+                ))),
+                BigInt::BigNInt(value) => Err(DecodeError::out_of_range(format!(
+                    "-1 - 0x{}",
+                    hex::encode(&*value)
+                ))),
+            }
         }
 
         fn to_plutus(self) -> PlutusData {
@@ -131,7 +137,7 @@ impl AsPlutus for i64 {
 }
 
 macro_rules! impl_tuple {
-    ($($param:ident),*) => {
+    ($($param:ident $index:expr),*) => {
         impl<$($param),*> AsPlutus for ($($param),*)
         where
             $($param: AsPlutus),*
@@ -139,7 +145,7 @@ macro_rules! impl_tuple {
             #[allow(non_snake_case)]
             fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
                 let [$($param),*] = parse_tuple(data)?;
-                Ok(($(AsPlutus::from_plutus($param)?),*))
+                Ok(($(AsPlutus::from_plutus($param).map_err(|e| e.with_field_name($index))?),*))
             }
 
             #[allow(non_snake_case)]
@@ -151,19 +157,19 @@ macro_rules! impl_tuple {
     };
 }
 
-impl_tuple!(T1, T2);
-impl_tuple!(T1, T2, T3);
-impl_tuple!(T1, T2, T3, T4);
-impl_tuple!(T1, T2, T3, T4, T5);
-impl_tuple!(T1, T2, T3, T4, T5, T6);
-impl_tuple!(T1, T2, T3, T4, T5, T6, T7);
-impl_tuple!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_tuple!(T1 0, T2 1);
+impl_tuple!(T1 0, T2 1, T3 2);
+impl_tuple!(T1 0, T2 1, T3 2, T4 3);
+impl_tuple!(T1 0, T2 1, T3 2, T4 3, T5 4);
+impl_tuple!(T1 0, T2 1, T3 2, T4 3, T5 4, T6 5);
+impl_tuple!(T1 0, T2 1, T3 2, T4 3, T5 4, T6 5, T7 6);
+impl_tuple!(T1 0, T2 1, T3 2, T4 3, T5 4, T6 5, T7 6, T8 7);
 
 impl AsPlutus for String {
     fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
         let bytes = BoundedBytes::from_plutus(data)?;
         String::from_utf8(bytes.to_vec())
-            .map_err(|err| DecodeError::Custom(format!("error decoding string: {err}")))
+            .map_err(|err| DecodeError::custom(format!("error decoding string: {err}")))
     }
 
     fn to_plutus(self) -> PlutusData {
@@ -183,7 +189,7 @@ impl<T: AsPlutus> AsPlutus for Option<T> {
             let [] = parse_variant(variant, fields)?;
             return Ok(None);
         }
-        Err(DecodeError::UnexpectedVariant { variant })
+        Err(DecodeError::unexpected_variant(variant))
     }
 
     fn to_plutus(self) -> PlutusData {
@@ -208,8 +214,12 @@ macro_rules! impl_map {
     () => {
         fn from_plutus(data: PlutusData) -> Result<Self, DecodeError> {
             let mut map = Self::new();
-            for (key, value) in parse_map(data)? {
-                map.insert(TKey::from_plutus(key)?, TVal::from_plutus(value)?);
+            for (index, (key, value)) in parse_map(data)?.into_iter().enumerate() {
+                let key = TKey::from_plutus(key)
+                    .map_err(|e| e.with_field_name(format!("[(key #{index})]")))?;
+                let value = TVal::from_plutus(value)
+                    .map_err(|e| e.with_field_name(format!("[(value #{index})]")))?;
+                map.insert(key, value);
             }
             Ok(map)
         }


### PR DESCRIPTION
Update error messages to make it easier to diagnose invalid plutus data:
 - All errors include a "path" pointing to where in the parsed response the error was thrown. 
 - Numeric primitive fields now validate that a parsed value is within the bounds for that type, instead of silently truncating or panicking.